### PR TITLE
#13 - check parent id when update

### DIFF
--- a/src/Traits/EloquentNestedSet.php
+++ b/src/Traits/EloquentNestedSet.php
@@ -423,26 +423,25 @@ trait EloquentNestedSet
     {
         try {
             DB::beginTransaction();
-            $node = static::findOrFail($this->id);
-            $parent = static::withoutGlobalScope('ignore_root')->findOrFail($node->{static::parentIdColumn()});
-            $parentRgt = $parent->{static::rightColumn()};
+            // Khi dùng queue, cần lấy lft và rgt mới nhất trong DB ra tính toán.
+            $this->refresh();
+            $parent     = static::withoutGlobalScope('ignore_root')->findOrFail($this->{static::parentIdColumn()});
+            $parentRgt  = $parent->{static::rightColumn()};
 
-            // Node mới sẽ được thêm vào sau (bên phải) các nodes cùng cha
-            $node->{static::depthColumn()} = $parent->{static::depthColumn()} + 1;
-            $node->{static::leftColumn()} = $parentRgt;
-            $node->{static::rightColumn()} = $parentRgt + 1;
-            $width = $node->getWidth();
-
-            // Cập nhật các node bên phải của node cha
+            // Tạo khoảng trống cho node hiện tại ở node cha mới, cập nhật các node bên phải của node cha mới
             static::withoutGlobalScope('ignore_root')
                 ->where(static::rightColumn(), '>=', $parentRgt)
-                ->update([static::rightColumn() => DB::raw(static::rightColumn() . " + $width")]);
+                ->update([static::rightColumn() => DB::raw(static::rightColumn() . " + 2")]);
 
             static::query()
                 ->where(static::leftColumn(), '>', $parentRgt)
-                ->update([static::leftColumn() => DB::raw(static::leftColumn() . " + $width")]);
+                ->update([static::leftColumn() => DB::raw(static::leftColumn() . " + 2")]);
 
-            $node->savePositionQuietly();
+            // Node mới sẽ được thêm vào sau (bên phải) các nodes cùng cha
+            $this->{static::depthColumn()}  = $parent->{static::depthColumn()} + 1;
+            $this->{static::leftColumn()}   = $parentRgt;
+            $this->{static::rightColumn()}  = $parentRgt + 1;
+            $this->savePositionQuietly();
             DB::commit();
         } catch (Throwable $th) {
             DB::rollBack();
@@ -460,34 +459,34 @@ trait EloquentNestedSet
         try {
             DB::beginTransaction();
             // Khi dùng queue, cần lấy lft và rgt mới nhất trong DB ra tính toán.
-            $node = static::findOrFail($this->id);
+            $this->refresh();
 
-            if ($node->hasDescendant($newParentId)) {
+            if ($this->hasDescendant($newParentId)) {
                 throw new Exception(
-                    "The new parent node with id={$newParentId} is a descendant of current node id={$node->id}"
+                    "The new parent node with id={$newParentId} is a descendant of current node id={$this->id}"
                 );
             }
 
-            $newParent = static::withoutGlobalScope('ignore_root')->findOrFail($newParentId);
-            $currentLft = $node->{static::leftColumn()};
-            $currentRgt = $node->{static::rightColumn()};
-            $currentDepth = $node->{static::depthColumn()};
-            $width = $node->getWidth();
-            $query = static::withoutGlobalScope('ignore_root')->whereNot(static::primaryColumn(), $node->id);
+            $newParent      = static::withoutGlobalScope('ignore_root')->findOrFail($newParentId);
+            $currentLft     = $this->{static::leftColumn()};
+            $currentRgt     = $this->{static::rightColumn()};
+            $currentDepth   = $this->{static::depthColumn()};
+            $width          = $this->getWidth();
+            $query          = static::withoutGlobalScope('ignore_root')->whereNot(static::primaryColumn(), $this->id);
 
             // Tạm thời để left và right các node con của node hiện tại ở giá trị âm
-            $node->descendants()->update([
+            $this->descendants()->update([
                 static::leftColumn() => DB::raw(static::leftColumn() . " * (-1)"),
                 static::rightColumn() => DB::raw(static::rightColumn() . " * (-1)"),
             ]);
 
             // Giả định node hiện tại bị xóa khỏi cây, cập nhật các node bên phải của node hiện tại
             (clone $query)
-                ->where(static::rightColumn(), '>', $node->{static::rightColumn()})
+                ->where(static::rightColumn(), '>', $this->{static::rightColumn()})
                 ->update([static::rightColumn() => DB::raw(static::rightColumn() . " - $width")]);
 
             (clone $query)
-                ->where(static::leftColumn(), '>', $node->{static::rightColumn()})
+                ->where(static::leftColumn(), '>', $this->{static::rightColumn()})
                 ->update([static::leftColumn() => DB::raw(static::leftColumn() . " - $width")]);
 
             // Tạo khoảng trống cho node hiện tại ở node cha mới, cập nhật các node bên phải của node cha mới
@@ -503,14 +502,16 @@ trait EloquentNestedSet
                 ->update([static::leftColumn() => DB::raw(static::leftColumn() . " + $width")]);
 
             // Cập nhật lại node hiện tại theo node cha mới
-            $node->{static::depthColumn()} = $newParent->{static::depthColumn()} + 1;
-            $node->{static::parentIdColumn()} = $newParentId;
-            $node->{static::leftColumn()} = $newParentRgt;
-            $node->{static::rightColumn()} = $newParentRgt + $width - 1;
-            $distance = $node->{static::rightColumn()} - $currentRgt;
-            $depthChange = $node->{static::depthColumn()} - $currentDepth;
+            $this->{static::depthColumn()}      = $newParent->{static::depthColumn()} + 1;
+            $this->{static::parentIdColumn()}   = $newParentId;
+            $this->{static::leftColumn()}       = $newParentRgt;
+            $this->{static::rightColumn()}      = $newParentRgt + $width - 1;
+            $this->savePositionQuietly();
 
             // Cập nhật lại các node con có left và right âm
+            $distance       = $this->{static::rightColumn()} - $currentRgt;
+            $depthChange    = $this->{static::depthColumn()} - $currentDepth;
+
             static::query()
                 ->where(static::leftColumn(), '<', 0 - $currentLft)
                 ->where(static::rightColumn(), '>', 0 - $currentRgt)
@@ -520,7 +521,6 @@ trait EloquentNestedSet
                     static::depthColumn() => DB::raw(static::depthColumn() . " + $depthChange"),
                 ]);
 
-            $node->savePositionQuietly();
             DB::commit();
         } catch (Throwable $th) {
             DB::rollBack();

--- a/tests/Feature/EloquentNestedSetTest.php
+++ b/tests/Feature/EloquentNestedSetTest.php
@@ -89,7 +89,7 @@ class EloquentNestedSetTest extends TestCase
     }
 
     /** @test */
-    public function it_must_to_throw_exception_if_new_parent_that_is_a_descendant_of_current_node()
+    public function it_must_to_throw_exception_if_new_parent_is_a_descendant_of_current_node()
     {
         $this->expectException(Exception::class);
         $c2 = Category::factory()->create(["name" => "Category 2"]);
@@ -349,8 +349,12 @@ class EloquentNestedSetTest extends TestCase
         $root = Category::withoutGlobalScope('ignore_root')->find(Category::ROOT_ID);
         $this->assertEquals([1, 2], [$root->lft, $root->rgt]);
 
+        $c2 = Category::factory()->create(["name" => "Category 2"]);
+        $this->assertEquals([Category::ROOT_ID, 1, 'Category 2', 2, 3], [$c2->parent_id, $c2->depth, $c2->name, $c2->lft, $c2->rgt]);
+        $root->refresh();
+        $this->assertEquals([1, 4], [$root->lft, $root->rgt]);
+
         Category::factory()->createMany([
-            ["name" => "Category 2"],
             ["name" => "Category 3"],
             ["name" => "Category 4"],
             ["name" => "Category 5"],
@@ -495,7 +499,7 @@ class EloquentNestedSetTest extends TestCase
     }
 
     /** @test */
-    public function it_can_calculate_rightly_lft_rgt_when_update()
+    public function it_can_calculate_rightly_lft_rgt_depth_when_update()
     {
         $root = Category::withoutGlobalScope('ignore_root')->find(Category::ROOT_ID);
         $this->assertEquals([1, 2], [$root->lft, $root->rgt]);


### PR DESCRIPTION
#13 

Fix:
- không cho update khi parent_id nhận được là con cháu của node hiện tại
- khi không dùng queue, các giá trị mới nhất của `left`, `right`, `parent_id` và `depth` phải được load lên instance của node hiện tại

Test: passed
![image](https://user-images.githubusercontent.com/105692913/176372487-3827c429-6ffe-4777-8fe3-9ab9446d3f12.png)
