### PR TITLE
Fix EloquentNestedSet not update other data

### DIFF
--- a/src/Traits/EloquentNestedSet.php
+++ b/src/Traits/EloquentNestedSet.php
@@ -181,7 +181,7 @@ trait EloquentNestedSet
             });
         });
 
-        static::updating(function (Model $model) {
+        static::updated(function (Model $model) {
             $oldParentId = $model->getOriginal(static::parentIdColumn());
             $newParentId = $model->{static::parentIdColumn()};
 
@@ -191,7 +191,7 @@ trait EloquentNestedSet
                 $model->{static::parentIdColumn()} = $oldParentId;
 
                 static::instantOrQueue(function () use ($model, $newParentId) {
-                    $model->handleTreeOnUpdating($newParentId);
+                    $model->handleTreeOnUpdated($newParentId);
                 });
             }
         });
@@ -455,7 +455,7 @@ trait EloquentNestedSet
      * @return void
      * @throws Throwable
      */
-    public function handleTreeOnUpdating($newParentId): void
+    public function handleTreeOnUpdated($newParentId): void
     {
         try {
             DB::beginTransaction();

--- a/tests/Feature/EloquentNestedSetTest.php
+++ b/tests/Feature/EloquentNestedSetTest.php
@@ -894,4 +894,16 @@ class EloquentNestedSetTest extends TestCase
         $this->assertEquals([CategorySoftDelete::ROOT_ID, 1, 'Category 13', 22, 23], [$c13->parent_id, $c13->depth, $c13->name, $c13->lft, $c13->rgt]);
         $this->assertEquals([1, 24], [$root->lft, $root->rgt]);
     }
+
+    /** @test */
+    public function it_can_return_correct_data_when_update()
+    {
+        $c2 = Category::factory()->create(["name" => "Category 2"]);
+        $c3 = Category::factory()->create(["name" => "Category 3"]);
+        $c3->name = "Category 333";
+        $c3->parent_id = $c2->id;
+        $c3->save();
+        $c3->refresh();
+        $this->assertEquals("Category 333", $c3->name);
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,6 +13,6 @@ class TestCase extends OrchestraTestCase
      */
     protected function defineDatabaseMigrations(): void
     {
-        $this->loadMigrationsFrom(__DIR__ . '/database/migrations');
+        $this->loadMigrationsFrom(__DIR__ . '/Database/migrations');
     }
 }


### PR DESCRIPTION
Trường hợp không dùng queue khi cập nhật 1 record thì chỉ có các column `lft`, `rgt`, `depth` và `parend_id` được update
Lý do là do dùng `refresh` trong `updating` event https://github.com/MediciVN/core/blob/main/src/Traits/EloquentNestedSet.php#L463

Giải pháp là sử dụng `updated` event

Passed
![image](https://user-images.githubusercontent.com/105692913/177500407-a49887ad-6ce9-4ca2-983f-badccedffab6.png)
